### PR TITLE
delete navbar partial

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,16 @@
 </head>
 <body>
 
-<%= render "navbar" %>
+<div class="navbar">
+  <p>SEARCH BAR PLACEHOLDER</p>
+  <% if current_user %>
+    <%= link_to "Logout", session_path, method: :delete %>
+  <% else %>
+    <%= link_to "Login", new_session_path %>
+    <%= link_to "Create Account", new_user_path %>
+  <% end %>
+</div>
+
 <%= yield %>
 
 </body>


### PR DESCRIPTION
Difficulties with rendering the partial- it wanted a copy in each view folder. So, in the interum, I copied the content of the navbar partial into the layout directly and removed the root_path reference as we haven't defined that yet.